### PR TITLE
v2.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "2.0.1"
+version = "2.0.2"
 description = ""
 authors = [{ name = "fl-korbes", email = "felipekorbes@live.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "channels" },


### PR DESCRIPTION
## Error handling normalization across all apps

### Summary

- **`plants/users`** — `User.DoesNotExist` was bubbling up as an unhandled 500. Now caught and returned as a proper 404 with `{"error": "User not found."}`
- **`plants/messages` + `political_culture/messages`** — Empty chat history was returning 204 with `{"message": "..."}`. Now always returns the serialized list (empty `[]` or populated) with 200 — consistent REST behavior for list endpoints
- **`plants/chatbot` + `political_culture/chatbot` + `political_culture/word_counter` + `cfflch/admission_status`** — Invalid request serializer errors were returning DRF's raw field-keyed dict. Now normalized to `{"error": "Invalid request data"}` across all routes
- **`plants/chatbot` logger** — Removed full LLM response body from log output (potential PII/noise in logs)

### Convention enforced

All error responses now use `{"error": "<message>"}` — a single consistent shape the frontend can always check via `response.error`.
